### PR TITLE
CDN alternatives in README and Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,16 @@ import fitch from 'fitch'
 const fitch = require('fitch')
 ```
 
-**UMD:**
+**CDN:**
 
+unpkg
 ```html
 <script src="https://unpkg.com/fitch/dist/index.umd.min.js"></script>
+```
+
+jsDelivr
+```html
+<script src="https://cdn.jsdelivr.net/g/fitch.js"></script>
 ```
 
 ### Make your first request:

--- a/docs/Intro.md
+++ b/docs/Intro.md
@@ -37,8 +37,14 @@ fitch.get(apiUrl)
 
 Also, you can use cdn:
 
+unpkg
 ```html
 <script src="https://unpkg.com/fitch/dist/index.umd.min.js"></script>
+```
+
+jsDelivr
+```html
+<script src="https://cdn.jsdelivr.net/g/fitch.js"></script>
 ```
 
 ### **Next: [Learn about the methods available](https://github.com/raphaelpor/fitch.js/blob/master/docs/Methods.md).**

--- a/docs/pt-br/Intro.md
+++ b/docs/pt-br/Intro.md
@@ -35,8 +35,14 @@ fitch.get(apiUrl)
 
 Também é possível usar o CDN:
 
+unpkg
 ```html
 <script src="https://unpkg.com/fitch/dist/index.umd.min.js"></script>
+```
+
+jsDelivr
+```html
+<script src="https://cdn.jsdelivr.net/g/fitch.js"></script>
 ```
 
 ### **Próximo: [Aprenda sobre os métodos disponíveis](https://github.com/raphaelpor/fitch.js/blob/master/docs/pt-br/Methods.md).**


### PR DESCRIPTION
[jsDelivr](https://github.com/jsdelivr/jsdelivr) is cool, because [allows loading multiple libraries with a single http request](https://github.com/jsdelivr/jsdelivr#load-multiple-files-with-single-http-request), automatic update, versioning, and others...

📚 