### PR TITLE
Add initializer with custom request options

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "homepage": "https://github.com/raphaelpor/fitch.js#readme",
   "main": "dist/index.js",
   "dependencies": {
-    "fetch-everywhere": "^1.0.5"
+    "fetch-everywhere": "^1.0.5",
+    "lodash.merge": "^4.6.0"
   },
   "devDependencies": {
     "ava": "^0.17.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,45 +1,64 @@
+import merge from 'lodash.merge';
 import request from './utils/request';
 
-function get(url, req) {
-  return request('GET', url, req);
+function intializer(rqst) {
+  function get(url, req) {
+    return rqst('GET', url, req);
+  }
+
+  function post(url, req) {
+    return rqst('POST', url, req);
+  }
+
+  function put(url, req) {
+    return rqst('PUT', url, req);
+  }
+
+  function patch(url, req) {
+    return rqst('PATCH', url, req);
+  }
+
+  function del(url, req) {
+    return rqst('DELETE', url, req);
+  }
+
+  function all(promises) {
+    return Promise.all(promises);
+  }
+
+  function init({
+      config = {},
+      interceptor = promise => promise,
+    } = {}) {
+    const customRqst = (method, url, req) => (
+      request(method, url, merge({}, config, req))
+        .then(interceptor)
+    );
+
+    return intializer(customRqst);
+  }
+
+  return {
+    all,
+    del,
+    get,
+    init,
+    patch,
+    post,
+    put,
+  };
 }
 
-function post(url, req) {
-  return request('POST', url, req);
-}
-
-function put(url, req) {
-  return request('PUT', url, req);
-}
-
-function patch(url, req) {
-  return request('PATCH', url, req);
-}
-
-function del(url, req) {
-  return request('DELETE', url, req);
-}
-
-function all(promises) {
-  return Promise.all(promises);
-}
-
-const fitch = {
-  all,
-  del,
-  get,
-  patch,
-  post,
-  put,
-};
+const fitch = intializer(request);
 
 export default fitch;
 
-export {
+export const {
   all,
   del,
   get,
+  init,
   patch,
   post,
   put,
-};
+} = fitch;

--- a/src/index.js
+++ b/src/index.js
@@ -27,9 +27,9 @@ function intializer(rqst) {
   }
 
   function init({
-      config = {},
-      interceptor = promise => promise,
-    } = {}) {
+    config = {},
+    interceptor = promise => promise,
+  } = {}) {
     const customRqst = (method, url, req) => (
       request(method, url, merge({}, config, req))
         .then(interceptor)

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,14 +1,14 @@
 export default function createConfig(method, {
-    body,
-    cache = 'default',
-    credentials,
-    headers = { 'Content-Type': 'application/json' },
-    integrity,
-    mode = 'cors',
-    redirect,
-    referrer,
-    referrerPolicy,
-  } = {}) {
+  body,
+  cache = 'default',
+  credentials,
+  headers = { 'Content-Type': 'application/json' },
+  integrity,
+  mode = 'cors',
+  redirect,
+  referrer,
+  referrerPolicy,
+} = {}) {
   let data;
 
   if (body) {

--- a/tests/test.index.js
+++ b/tests/test.index.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { get, put, post, patch, del, all, error } from '../src'
+import fitch, { get, put, post, patch, del, all, init, error } from '../src'
 
 const baseUrl = 'http://localhost:8000/cats'
 
@@ -9,6 +9,13 @@ const reqUpdate = {
 
 const reqPost = {
   body: { name: 'New cat' },
+}
+
+const initOpts = {
+  config: { body: { friendName: 'Special Cat' } },
+  interceptor: ({ data: { name, friendName } }) => (
+    name === 'New cat' && friendName === 'Special Cat'
+  )
 }
 
 test('method: get', t =>
@@ -52,4 +59,13 @@ test('method: all', t => {
       t.is(result1, 'ok-1', 'result1 is ok-1')
       t.is(result2, 'ok-2', 'result2 is ok-2')
     })
+})
+
+test('method: init', t => {
+  t.not(fitch.init(), fitch)
+
+  return init(initOpts)
+    .post(`${baseUrl}/new/`, reqPost)
+    .then(isExpectedReturn => t.true(isExpectedReturn,'config and interceptor applied to request'))
+    .catch(data => t.pass())
 })


### PR DESCRIPTION
It makes possible to have a _fitch_ copy that merges some options to all requests. i.e: Always add same headers.
Also, it can attach a function to be called at the end of every request (the _interceptor_ of issue #4).

You can import a regular fitch on your project alongside other copies with different configurations applied.

Close #4